### PR TITLE
Replace ```ignore with ```text

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -166,7 +166,7 @@ fn number(input: &str) -> IResult<&str, KdlNodeValue, KdlParseError<&str>> {
     ))(input)
 }
 
-/// ```ignore
+/// ```text
 /// decimal := integer ('.' [0-9]+)? exponent?
 /// exponent := ('e' | 'E') integer
 /// integer := sign? [1-9] [0-9_]*
@@ -188,7 +188,7 @@ fn float(input: &str) -> IResult<&str, f64, KdlParseError<&str>> {
     )(input)
 }
 
-/// ```ignore
+/// ```text
 /// decimal := integer ('.' [0-9]+)? exponent?
 /// exponent := ('e' | 'E') integer
 /// integer := sign? [1-9] [0-9_]*


### PR DESCRIPTION
Using the `ignore` marker makes `cargo test` think this is rust code that should be ignored, which means it prints an "ignored" line in the test output. It also makes `cargo doc --document-private-items` attempt to colorize it as rust code. Marking this as `text` instead fixes both issues.